### PR TITLE
Default to composer.phar as destination filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ RUN php tiny-composer-installer.php /usr/local/bin/composer \
 ## Requirements and limitations
 
 * We haven’t tested this tool in a lot of different environments yet. If it doesn’t work for you, please tell us. However, we don’t aim to support every possible environment.
-* [`allow_url_fopen`](http://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen) and the [OpenSSL extension](http://php.net/manual/en/book.openssl.php) need to be available/enabled.
+* [`allow_url_fopen`](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen) and the [OpenSSL extension](https://secure.php.net/manual/en/book.openssl.php) need to be available/enabled.
 * You need PHP 5.3.2 to run Composer. Tiny Composer Installer doesn’t check for that. The installer itself requires at least PHP 5.2.
 
 ## Installation
@@ -45,7 +45,7 @@ Wouldn’t it be nice if the installer wasn’t so large, so you could actually 
 
 You can pass a destination filename as a parameter. Please note that if the download and signature checks succeed, the file will be overwritten without asking. If you don’t supply a filename, `composer.phar` in the current directory will be used.
 
-Whether you supplied a parameter or not, when Tiny Composer Installer succeeds it will echo the [`realpath()`](http://php.net/manual/en/function.realpath.php) of the destination filename to standard output and return with an exit code of zero. On error, stdout will be empty and a non-zero error code will be returned. This allows you to do something like this:
+Whether you supplied a parameter or not, when Tiny Composer Installer succeeds it will echo the [`realpath()`](https://secure.php.net/manual/en/function.realpath.php) of the destination filename to standard output and return with an exit code of zero. On error, stdout will be empty and a non-zero error code will be returned. This allows you to do something like this:
 
 ```bash
 phar="$(php tiny-composer-installer.php "$(mktemp -t)")" && php "$phar" install && rm "$phar"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a small, simple and easily auditable tool that downloads [Composer](http
 
 ## Give me the tl;dr.
 
-As soon as you’ve downloaded `tiny-composer-installer.php`, run `php tiny-composer-installer.php composer.phar` to get the current stable version of Composer saved to `composer.phar`.
+As soon as you’ve downloaded `tiny-composer-installer.php`, run `php tiny-composer-installer.php` to get the current stable version of Composer saved to `composer.phar` in the current directory.
 
 When you’re using a `Dockerfile` based on [the official PHP images](https://hub.docker.com/_/php/), you can do it like this:
 
@@ -43,15 +43,15 @@ Wouldn’t it be nice if the installer wasn’t so large, so you could actually 
 
 ## Usage
 
-You can pass a destination filename as a parameter. Please note that if the download and signature checks succeed, the file will be overwritten without asking. If you don’t supply a filename, a random one in your system’s temp directory will be generated.
+You can pass a destination filename as a parameter. Please note that if the download and signature checks succeed, the file will be overwritten without asking. If you don’t supply a filename, `composer.phar` in the current directory will be used.
 
-Whether you supplied a parameter or not, when Tiny Composer Installer succeeds it will echo the destination filename to standard output and return with an exit code of zero. On error, stdout will be empty and a non-zero error code will be returned. This allows you to do something like this:
+Whether you supplied a parameter or not, when Tiny Composer Installer succeeds it will echo the [`realpath()`](http://php.net/manual/en/function.realpath.php) of the destination filename to standard output and return with an exit code of zero. On error, stdout will be empty and a non-zero error code will be returned. This allows you to do something like this:
 
 ```bash
-phar="$(php tiny-composer-installer.php)" && php "$phar" install && rm "$phar"
+phar="$(php tiny-composer-installer.php "$(mktemp -t)")" && php "$phar" install && rm "$phar"
 ```
 
-If that’s too fancy for you, this is how you install Composer globally to `/usr/local/bin`.
+If that’s too fancy for you, this is how you install Composer globally to `/usr/local/bin`:
 
 ```bash
 sudo php tiny-composer-installer.php /usr/local/bin/composer

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Whether you supplied a parameter or not, when Tiny Composer Installer succeeds i
 phar="$(php tiny-composer-installer.php "$(mktemp -t)")" && php "$phar" install && rm "$phar"
 ```
 
+(Please note that this example requires GNU `mktemp` and won’t work on macOS or BSD.)
+
 If that’s too fancy for you, this is how you install Composer globally to `/usr/local/bin`:
 
 ```bash

--- a/tests/DownloadTest.php
+++ b/tests/DownloadTest.php
@@ -55,7 +55,7 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
         return static::execute(implode(' ', array_merge([
             'php',
             escapeshellarg(__DIR__ . '/../tiny-composer-installer.php'),
-        ], $params)));
+        ], array_map('escapeshellarg', $params))));
     }
 
     /**
@@ -64,7 +64,7 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
     public function testTinyAndOfficialDownloadTheSameComposer()
     {
         $tinyFile = tempnam(sys_get_temp_dir(), 'tiny-composer-');
-        $result = static::executeTCI([escapeshellarg($tinyFile)]);
+        $result = static::executeTCI([$tinyFile]);
         $this->assertSame(0, $result['rc'], 'Tiny installer failed.');
         $this->assertFileEquals(static::$officialComposer, $tinyFile, 'Tiny installer downloads a different file');
         unlink($tinyFile);

--- a/tests/DownloadTest.php
+++ b/tests/DownloadTest.php
@@ -50,20 +50,50 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    protected static function executeTCI(array $params)
+    {
+        return static::execute(implode(' ', array_merge([
+            'php',
+            escapeshellarg(__DIR__ . '/../tiny-composer-installer.php'),
+        ], $params)));
+    }
+
     /**
      * @medium
      */
     public function testTinyAndOfficialDownloadTheSameComposer()
     {
         $tinyFile = tempnam(sys_get_temp_dir(), 'tiny-composer-');
-        $result = static::execute(implode(' ', [
-            'php',
-            escapeshellarg(__DIR__ . '/../tiny-composer-installer.php'),
-            escapeshellarg($tinyFile),
-        ]));
+        $result = static::executeTCI([escapeshellarg($tinyFile)]);
         $this->assertSame(0, $result['rc'], 'Tiny installer failed.');
         $this->assertFileEquals(static::$officialComposer, $tinyFile, 'Tiny installer downloads a different file');
         unlink($tinyFile);
+    }
+
+    /**
+     * @medium
+     */
+    public function testDefaultOutputFilename()
+    {
+        $default = 'composer.phar';
+        $this->assertFileNotExists($default, "$default already exists -- test environment clean?");
+        $result = static::executeTCI([]);
+        $this->assertSame(0, $result['rc'], 'TCI failed.');
+        $this->assertSame(realpath($default), $result['out'][0], "TCI didn't write to $default.");
+        unlink($default);
+    }
+
+    /**
+     * @medium
+     */
+    public function testRelativeOutputFilename()
+    {
+        $destination = sprintf('composer.%d.phar', time());
+        $this->assertFileNotExists($destination, "$destination already exists -- test environment clean?");
+        $result = static::executeTCI([$destination]);
+        $this->assertSame(0, $result['rc'], 'TCI failed.');
+        $this->assertSame(realpath($destination), $result['out'][0], "TCI didn't write to $destination.");
+        unlink($destination);
     }
 
 }

--- a/tiny-composer-installer.php
+++ b/tiny-composer-installer.php
@@ -9,6 +9,7 @@
 
 $my_version = '0.1.0';
 $base_url = 'https://getcomposer.org';
+$default_filename = 'composer.phar';
 
 // Retrieved from <https://composer.github.io/pubkeys.html>, only valid for tagged releases.
 $signature_key = <<<END
@@ -39,12 +40,12 @@ usage: tiny-composer-installer.php [filename]
 version: {$my_version}
 
 Download Composer, check the download against a hardcoded signature key and save
-it to a file. The filename parameter is optional, if you don't supply one, a
-temp file will be used.
+it to a file. The filename parameter is optional. If you don't supply one, the
+name {$default_filename} will be used.
 
-On success, the file name will be written to stdout, for easy handling in
-scripts. On failure, nothing will be written to stdout, the return code will be
-non-zero and there will be an error message in stderr.
+On success, the absolute file name will be written to stdout, in case you need
+that in a script. On failure, nothing will be written to stdout, the return code
+will be non-zero and there will be an error message in stderr.
 
 Please note that the output file will be overwritten without asking, but only if
 the download and signature check were successful.
@@ -60,7 +61,7 @@ $version = select_version(fetch_versions($base_url), 'stable');
 $phar = fetch_phar($base_url, $version);
 $signature = fetch_signature($base_url, $version);
 check_signature($phar, $signature, $signature_key);
-echo write_phar($phar) . PHP_EOL;
+echo write_phar($phar, $default_filename) . PHP_EOL;
 
 function check_signature($subj, $sig, $key)
 {
@@ -130,12 +131,12 @@ function select_version($versions, $channel)
     return $version[0];
 }
 
-function write_phar($phar)
+function write_phar($phar, $default_filename)
 {
-    $file = ($_SERVER['argc'] >= 2) ? $_SERVER['argv'][1] : tempnam(sys_get_temp_dir(), 'composer-');
+    $file = ($_SERVER['argc'] >= 2) ? $_SERVER['argv'][1] : $default_filename;
     if (!file_put_contents($file, $phar)) {
         throw new \RuntimeException("could not write PHAR to $file");
     }
     chmod($file, 0755);
-    return $file;
+    return realpath($file);
 }

--- a/tiny-composer-installer.php
+++ b/tiny-composer-installer.php
@@ -137,6 +137,8 @@ function write_phar($phar, $default_filename)
     if (!file_put_contents($file, $phar)) {
         throw new \RuntimeException("could not write PHAR to $file");
     }
-    chmod($file, 0755);
+    if (!chmod($file, 0755)) {
+        trigger_error('could not chmod() output file to be executable', E_USER_WARNING);
+    }
     return realpath($file);
 }


### PR DESCRIPTION
The reasoning behind this is basically POLA. We shouldn’t differ from the official installer just for an obscure convenience feature that can easily be replaced by passing `$(mktemp -t)` when calling TCI.

This could be regarded as a breaking change. However, if you didn’t pass an output file before, you had to read stdout to find the filename. With the change, you can still do this: stdout will contain the path to `composer.phar`.